### PR TITLE
Update SapMachine URL

### DIFF
--- a/src/data/jdks.ts
+++ b/src/data/jdks.ts
@@ -317,7 +317,7 @@ const jdks: JDK[] = [
     id: 'sapmchn',
     vendor: 'SAP',
     distribution: 'SapMachine',
-    url: 'https://sap.github.io/SapMachine/',
+    url: 'https://sapmachine.io/',
     architecture: {
       short: [shortArchList.x86_64, shortArchList.arm64],
       long: [


### PR DESCRIPTION
The old URL https://sap.github.io/SapMachine/ is outdated and shall be sunsetted.